### PR TITLE
Overflow Patched

### DIFF
--- a/chell.c
+++ b/chell.c
@@ -126,11 +126,12 @@ void initPrompt()
 int splitString(char *split[], char *string, char *delim)
 {
     char *arg = strtok(string, delim);
+    size_t size = 256;
 
     int argc = 0;
     while (arg != NULL)
     {
-        strcpy(split[argc], arg);
+        strncpy(split[argc], arg, size);
         argc++;
         arg = strtok(NULL, delim);
     }

--- a/chell.c
+++ b/chell.c
@@ -168,7 +168,7 @@ void executeCommand(char *commandString, struct executable *executables)
     {
         if (strcmp(argv[0], executables[i].name) == 0)
         {
-            size_t size = 256
+            size_t size = 256;
             snprintf(commandPath, size,"%s/%s", executables[i].path, executables[i].name);
             programExists = 1;
             break;

--- a/chell.c
+++ b/chell.c
@@ -168,7 +168,8 @@ void executeCommand(char *commandString, struct executable *executables)
     {
         if (strcmp(argv[0], executables[i].name) == 0)
         {
-            sprintf(commandPath,"%s/%s", executables[i].path, executables[i].name);
+            size_t size = 256
+            snprintf(commandPath, size,"%s/%s", executables[i].path, executables[i].name);
             programExists = 1;
             break;
         }


### PR DESCRIPTION
sprintf is unsafe and unbounded (will keep copying strings till null-byte), so any file with name+path, will cause an overflow, and may lead to RCE (it is funny though, as you are already in shell :D, however possible different uses are typically unsafe (think shellshock for an example), another example is a non-executable file (an image) with malicious name, will potentially gain RCE too