### PR TITLE
create dedicated command infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJ = chell
 CC = gcc
 
 # list of all .c/.cpp files to be compiled (space separated, without extension)
-FILES = chell chad-readline
+FILES = chell chad-readline commands
 
 #--------(DO NOT EDIT BELOW)--------#
 

--- a/src/chell.h
+++ b/src/chell.h
@@ -1,12 +1,8 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/wait.h>
-#include <sys/types.h>
 #include <limits.h>
 #include <dirent.h>
-#include <errno.h>
 #include <signal.h> 
 
 #include "defs.h"
@@ -31,8 +27,6 @@ int splitString(char *split[], char *string, char *delim);
 int splitCommand(char *argv[], char *command);
 
 void executeCommand(char *commandString, struct executable *executables);
-
-void cd(char *path);
 
 void sigintHandler(int signal_number);
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,0 +1,39 @@
+#include "commands.h"
+
+struct command commands[] = {
+    { "cd", cd, "Change directory" },
+    { NULL, NULL, NULL}
+};
+
+struct command *is_builtin(char *name)
+{
+    for (int i = 0; commands[i].name; ++i)
+    {
+        if (strcmp(name, commands[i].name) == 0)
+            return &commands[i];
+    }
+
+    return NULL;
+}
+
+void cd(char *path)
+{
+    if (path == NULL)
+    {
+        path = getenv("HOME");
+    }
+
+    int status = chdir(path);
+
+    if (status == 0)
+        setenv("PWD", getcwd(NULL, 4096), 1);
+    else if (status == -1)
+    {
+        if (errno == EACCES)
+            printf("%s: Permission denied.\n", path);
+        else if (errno == ENOENT)
+            printf("%s: Doesn't exist.\n", path);
+        else if (errno == ENOTDIR)
+            printf("%s: Not a directory.\n", path);
+    }
+}

--- a/src/commands.h
+++ b/src/commands.h
@@ -1,0 +1,17 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+struct command {
+    char *name;
+    void (*func)(char*);
+    char *help;
+};
+
+struct command *is_builtin(char *name);
+void cd(char *path);
+
+extern struct command commands[];


### PR DESCRIPTION
built in commands are put into a dedicated array of command struct that is iterated through using a helper method.
the check for built in commands is moved above the program execution code to not have installed programs override built-ins which fixes #15

after checking bash seems to do the [same](https://github.com/bminor/bash/blob/64447609994bfddeef1061948022c074093e9a9f/lib/readline/examples/fileman.c#L86)