### PR TITLE
Added Chell command history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJ = chell
 CC = gcc
 
 # list of all .c/.cpp files to be compiled (space separated, without extension)
-FILES = chell chad-readline
+FILES = chell chad-readline chad-history
 
 #--------(DO NOT EDIT BELOW)--------#
 

--- a/src/chad-history.c
+++ b/src/chad-history.c
@@ -9,14 +9,15 @@ struct history_manager {
 struct history_manager old_history, new_history;
 
 void initHistory() {
-    history_file = (char*) malloc(strlen(getenv("HOME")) + strlen(HISTORY_FILE) + 1);
+    history_file = (char *) malloc(sizeof(char)*(strlen(getenv("HOME")) + strlen(HISTORY_FILE) + 1));
     strcpy(history_file, getenv("HOME"));
     strcat(history_file, HISTORY_FILE);
     initNewHistory();
     loadHistory();
-    handler.next = *getNext;
-    handler.prev = *getPrev;
-    handler.add = *addHistory;
+    historyHandler.getNext = *getNext;
+    historyHandler.getPrev = *getPrev;
+    historyHandler.add = *addHistory;
+    buffer = (char *) malloc(sizeof(char)*ARG_MAX);
 }
 
 void initNewHistory() {
@@ -24,43 +25,40 @@ void initNewHistory() {
     new_history.history_index = new_history.history_size = 0;
 }
 
-char *getNext() {
-    char *command = (char *) malloc(sizeof(char)*ARG_MAX);
+char *getNext(char *command) { // Test fail on first cmd to return buffer;
     if (new_history.history_index == -1) {
-        if (old_history.history_index == old_history.history_size-1) {
+        if (old_history.history_index == old_history.history_size - 1) {
             old_history.history_index++;
-            strcpy(command, new_history.history_list[++new_history.history_index]);
+            return new_history.history_list[++new_history.history_index];
         } else {
-            strcpy(command, old_history.history_list[++old_history.history_index]);
+            return old_history.history_list[++old_history.history_index];
         }
-    } else if (new_history.history_index != new_history.history_size) {
-        strcpy(command, new_history.history_list[++new_history.history_index]);
+    } else if (new_history.history_index < new_history.history_size - 1) {
+        return new_history.history_list[++new_history.history_index];
     } else {
-        free(command);
-        command = NULL;
+        if (new_history.history_index == new_history.history_size - 1) new_history.history_index++;
+        // if(new_history.history_size == 0) return command;
+        return buffer;
     }
-    return command;
 }
 
-char *getPrev() {
-    char *command = (char *) malloc(sizeof(char)*ARG_MAX);
+char *getPrev(char *command) {
+    if(new_history.history_index == new_history.history_size) strcpy(buffer, command);
     if (new_history.history_index == -1) {
         if(old_history.history_index > 0) old_history.history_index--;
-        strcpy(command, old_history.history_list[old_history.history_index]);
+        return old_history.history_list[old_history.history_index];
     } else if (new_history.history_index == 0) {
         if(old_history.history_size != 0) {
             new_history.history_index --;
-            strcpy(command, old_history.history_list[--old_history.history_index]);
+            return old_history.history_list[--old_history.history_index];
         } else if (new_history.history_size != 0) {
-            strcpy(command, new_history.history_list[new_history.history_index]);
+            return new_history.history_list[new_history.history_index];
         } else {
-            free(command);
-            command = NULL;
+            return buffer;
         }
     } else {
-        strcpy(command, new_history.history_list[--new_history.history_index]);
+        return new_history.history_list[--new_history.history_index];
     }
-    return command;
 }
 
 void addHistory(char *command) {

--- a/src/chad-history.c
+++ b/src/chad-history.c
@@ -1,0 +1,122 @@
+#include "chad-history.h"
+
+struct history_manager {
+    char **history_list;
+    int history_index;
+    unsigned int history_size;
+};
+
+struct history_manager old_history, new_history;
+
+void initHistory() {
+    history_file = (char*) malloc(strlen(getenv("HOME")) + strlen(HISTORY_FILE) + 1);
+    strcpy(history_file, getenv("HOME"));
+    strcat(history_file, HISTORY_FILE);
+    initNewHistory();
+    loadHistory();
+    handler.next = *getNext;
+    handler.prev = *getPrev;
+    handler.add = *addHistory;
+}
+
+void initNewHistory() {
+    new_history.history_list = calloc(BATCH_SIZE, sizeof(char *));
+    new_history.history_index = new_history.history_size = 0;
+}
+
+char *getNext() {
+    char *command = (char *) malloc(sizeof(char)*ARG_MAX);
+    if (new_history.history_index == -1) {
+        if (old_history.history_index == old_history.history_size-1) {
+            old_history.history_index++;
+            strcpy(command, new_history.history_list[++new_history.history_index]);
+        } else {
+            strcpy(command, old_history.history_list[++old_history.history_index]);
+        }
+    } else if (new_history.history_index != new_history.history_size) {
+        strcpy(command, new_history.history_list[++new_history.history_index]);
+    } else {
+        free(command);
+        command = NULL;
+    }
+    return command;
+}
+
+char *getPrev() {
+    char *command = (char *) malloc(sizeof(char)*ARG_MAX);
+    if (new_history.history_index == -1) {
+        if(old_history.history_index > 0) old_history.history_index--;
+        strcpy(command, old_history.history_list[old_history.history_index]);
+    } else if (new_history.history_index == 0) {
+        if(old_history.history_size != 0) {
+            new_history.history_index --;
+            strcpy(command, old_history.history_list[--old_history.history_index]);
+        } else if (new_history.history_size != 0) {
+            strcpy(command, new_history.history_list[new_history.history_index]);
+        } else {
+            free(command);
+            command = NULL;
+        }
+    } else {
+        strcpy(command, new_history.history_list[--new_history.history_index]);
+    }
+    return command;
+}
+
+void addHistory(char *command) {
+    if(new_history.history_size == BATCH_SIZE) reloadHistory();
+    new_history.history_list[new_history.history_size++] = command;
+    new_history.history_index = new_history.history_size;
+    old_history.history_index = old_history.history_size;
+}
+
+void loadHistory() {
+    FILE *file;
+    unsigned int count = 0;
+
+    file = fopen(history_file, "r");
+    if(file != NULL) {
+        char c = fgetc(file);
+        while(c != EOF) {
+            if(c == '\n') count ++;
+            c = fgetc(file);
+        }
+
+        old_history.history_list = calloc(count, sizeof(char *));
+        old_history.history_size = count;
+        fseek(file, 0, SEEK_SET);
+        for(old_history.history_index = 0; old_history.history_index<count; old_history.history_index++) {
+            char *line = (char *) malloc(sizeof(char)*ARG_MAX);
+            int index = 0;
+            c = fgetc(file);
+            while(c != '\n') {
+                line[index++] = c;
+                c = fgetc(file);
+            }
+            old_history.history_list[old_history.history_index] = line;
+        }
+        fclose(file);
+    }
+}
+
+void saveHistory() {
+    FILE *file;
+    file = fopen(history_file, "a");
+    if(file != NULL) {
+        for(int i=0; i<new_history.history_size; i++) {
+            fprintf(file, "%s\n", new_history.history_list[i]);
+        }
+        fclose(file);
+    }
+    free(new_history.history_list);
+}
+
+void reloadHistory() {
+    saveHistory();
+    while(old_history.history_size --) {
+        free(old_history.history_list[old_history.history_size]);
+    }
+    free(old_history.history_list);
+    initNewHistory();
+    loadHistory();
+}

--- a/src/chad-history.h
+++ b/src/chad-history.h
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "defs.h"
+
+#define BATCH_SIZE 1024
+#define HISTORY_FILE "/.chell_history"
+
+char *history_file;
+
+struct history_handler {
+    char *(*next)();
+    char *(*prev)();
+    void (*add)(char *);
+} handler;
+
+void initHistory(void);
+void loadHistory(void);
+void saveHistory(void);
+void reloadHistory(void);
+void initNewHistory(void);
+
+char *getNext(void);
+char *getPrev(void);
+void addHistory(char *command);
+
+extern struct history_handler handler;

--- a/src/chad-history.h
+++ b/src/chad-history.h
@@ -5,16 +5,20 @@
 
 #include "defs.h"
 
+#ifndef CHAD_HISTORY
+#define CHAD_HISTORY
 #define BATCH_SIZE 1024
 #define HISTORY_FILE "/.chell_history"
 
 char *history_file;
 
 struct history_handler {
-    char *(*next)();
-    char *(*prev)();
+    char *(*getNext)(char *);
+    char *(*getPrev)(char *);
     void (*add)(char *);
-} handler;
+} historyHandler;
+
+char *buffer;
 
 void initHistory(void);
 void loadHistory(void);
@@ -22,8 +26,9 @@ void saveHistory(void);
 void reloadHistory(void);
 void initNewHistory(void);
 
-char *getNext(void);
-char *getPrev(void);
+char *getNext(char *command);
+char *getPrev(char *command);
 void addHistory(char *command);
 
-extern struct history_handler handler;
+extern struct history_handler historyHandler;
+#endif

--- a/src/chad-readline.c
+++ b/src/chad-readline.c
@@ -71,8 +71,21 @@ char *readline(char *prompt)
         {
             if (escapeCharacter == LEFT_ARROW);  //Move Left
             if (escapeCharacter == RIGHT_ARROW); //Move right
-            if (escapeCharacter == UP_ARROW);    //History up
-            if (escapeCharacter == DOWN_ARROW);  //History down
+            if (escapeCharacter == UP_ARROW) {   //History up
+                char *cmd = historyHandler.getPrev(line);
+                if(cmd != NULL) {
+                    replaceCommandDisplay(prompt, cmd, line);
+                }
+                cursor = strlen(line);
+            }
+            if (escapeCharacter == DOWN_ARROW) { //History down
+                char *cmd = historyHandler.getNext(line);
+                // printf("\n%d -> %s\n", cmd, cmd);
+                if(cmd != NULL) {
+                    replaceCommandDisplay(prompt, cmd, line);
+                }
+                cursor = strlen(line);
+            }
         }
         else
         {
@@ -80,6 +93,7 @@ char *readline(char *prompt)
             {
                 line[cursor] = '\0';
                 printf("\n");
+                historyHandler.add(line);
                 return line;
             }
             else if(!handle_special(input, line, &cursor))
@@ -96,7 +110,12 @@ char *readline(char *prompt)
 }
 
 
-
+void replaceCommandDisplay(char *prompt, char *command, char *line) {
+    int len = strlen(prompt) + strlen(line);
+    while(len--) printf("\b \b");
+    printf("%s%s", prompt, command);
+    strcpy(line, command);
+}
 
 
 /*

--- a/src/chad-readline.h
+++ b/src/chad-readline.h
@@ -3,6 +3,7 @@
 #include <termios.h>
 #include <stdlib.h>
 #include "defs.h"
+#include "chad-history.h"
 
 
 /* Function to detect arrow key pressed in incoming stream
@@ -33,3 +34,5 @@ char getch(void);
 
 // Read 1 character with echo
 char getche(void);
+
+void replaceCommandDisplay(char *prompt, char *command, char *line);

--- a/src/chell.c
+++ b/src/chell.c
@@ -12,6 +12,9 @@ int main()
     getPATHLocations(PATHdirs, getenv("PATH"));
     struct executable *executables = getFilesFromDirectories(PATHdirs, numberOfDirs);
 
+    // Initialize command history handling functions
+    initHistory();
+
     char *command;
     while (1)
     {
@@ -143,8 +146,10 @@ int splitCommand(char *argv[], char *command)
 
 void executeCommand(char *commandString, struct executable *executables)
 {
-    if (strncmp(commandString, "exit", 4) == 0 || strncmp(commandString, "quit", 4) == 0 || strncmp(commandString, "q", 1) == 0)
+    if (strncmp(commandString, "exit", 4) == 0 || strncmp(commandString, "quit", 4) == 0 || strncmp(commandString, "q", 1) == 0) {
+        saveHistory();
         exit(0);
+    } 
 
     pid_t processID;
     char *argv[PATH_MAX];

--- a/src/chell.h
+++ b/src/chell.h
@@ -11,6 +11,7 @@
 
 #include "defs.h"
 #include "chad-readline.h"
+#include "chad-history.h"
 
 struct executable
 {


### PR DESCRIPTION
Added functionality to get previously ran commands on Up/Down arrow press.
Fixes #3 
Tasks:
- [x] get previous command on up arrow key press
- [x] get next command on down arrow key press
- [x] commands are saved to `~/.chell_history` after quit
- [x] commands are loaded from `~/.chell_history` if file exists
- [x] code documentation and formating
- [x] pull from master and resolve any conflict

Known Bugs:
- For the first command to be executed on chell the getNext is not getting buffer pointer correctly (getPrev works perfectly)
- If history log file doesn't exist it getNext function returns garbage value (getPrev works perfectly)