### PR TITLE
Fixed the duplicate symbol error. Got rid of warnings.

### DIFF
--- a/src/chad-history.c
+++ b/src/chad-history.c
@@ -1,4 +1,5 @@
 #include "chad-history.h"
+#include "chell.h"
 
 struct history_manager {
     char **history_list;

--- a/src/chad-readline.c
+++ b/src/chad-readline.c
@@ -107,7 +107,7 @@ void clearBuffer()
 
 char *readline(char *prompt)
 {
-    printf(prompt);
+    printf("%s", prompt);
     char *line = (char*) malloc(sizeof(char)*ARG_MAX);   //Current input
     
     cursor = 0;
@@ -116,7 +116,7 @@ char *readline(char *prompt)
     char input;
     unsigned char escapeCharacter;
 
-    while(input = getch())
+    while((input = getch()))
     {
         char status = escape_detected(input, &escapeCharacter);
         if (status == 0 || status == 1) continue;
@@ -221,6 +221,8 @@ char *readline(char *prompt)
             }
         }
     }
+
+    return NULL;
 }
 
 void replaceCommandDisplay(char *prompt, char *command, char *line)

--- a/src/chell.c
+++ b/src/chell.c
@@ -1,6 +1,8 @@
 #include "chell.h"
 #include "commands.h"
 
+static int nExecutables = 0;
+
 int main()
 {
     signal(SIGINT, sigintHandler);
@@ -24,7 +26,7 @@ int main()
         command = readline("");  
        
         //If not an empty command
-        if (strlen(command) != 0 && !isWhiteSpaces(command))
+        if (command && strlen(command) != 0 && !isWhiteSpaces(command))
             executeCommand(command, executables);
     }
 

--- a/src/chell.h
+++ b/src/chell.h
@@ -18,7 +18,6 @@ struct executable
 int getPATHLocationCount(char *PATH);
 void getPATHLocations(char *directories[], char *PATH);
 
-int nExecutables = 0;
 struct executable *getFilesFromDirectories(char **dir, int numberOfDirectory);
 
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -5,7 +5,10 @@
 #define SHELL_NAME "Chell"
 #define HISTORY_SIZE 1024
 #define HISTORY_FILE "/.chell_history"
+
+#ifndef ARG_MAX // it's already defined in sys/syslimits.h on macos
 #define ARG_MAX sysconf(_SC_ARG_MAX)
+#endif
 
 #define max(a,b) \
    ({ __typeof__ (a) _a = (a); \


### PR DESCRIPTION
The symbol was duplicated because nExecutables declared in the chell.h header. So if the header was declared more than once, the variable would be defined twice.
The solution was to move that variable to the .c file and mark it as static. The static keyword makes sure that the symbol is local to that translation unit only, so even if there is a variable with the same name in other translation units, the names won't collide.

The warnings were simple enough to get rid of, I think the diff will show what I did.